### PR TITLE
Override FetchContent flag

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -35,6 +35,7 @@ override_dh_auto_configure:
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
 		-DAMENT_PREFIX_PATH="@(InstallationPrefix)" \
 		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
+		-DFETCHCONTENT_FULLY_DISCONNECTED=OFF \
 		$(BUILD_TESTING_ARG)
 
 override_dh_auto_build:


### PR DESCRIPTION
Override default FETCHCONTENT_FULLY_DISCONNECTED flag to enable fetching prebuilt Foxglove SDK binaries for Foxglove Bridge.

Currently [failing in the ROS rolling build farm](https://build.ros2.org/job/Rbin_unv8_uNv8__foxglove_bridge__ubuntu_noble_arm64__binary/) because we can't fetch the Foxglove SDK as a required dependency.

Will also merge this PR to:

- `debian/kilted/foxglove_bridge`
- `debian/jazzy/foxglove_bridge`
- `debian/humble/foxglove_bridge`

once the new version of Foxglove Bridge is bloomed to those distros.

See also: ros2-gbp/rosbag2-release#10